### PR TITLE
Added missing urls for 10.4 & windows client support (BootCamp,QuickTime,

### DIFF
--- a/code/reposadolib/reposadocommon.py
+++ b/code/reposadolib/reposadocommon.py
@@ -64,9 +64,11 @@ def pref(prefname):
     '''Returns a preference.'''
     default_prefs = {
         'AppleCatalogURLs':                    ['http://swscan.apple.com/content/catalogs/index.sucatalog',
+'http://swscan.apple.com/content/catalogs/index-1.sucatalog'
 'http://swscan.apple.com/content/catalogs/others/index-leopard.merged-1.sucatalog',
 'http://swscan.apple.com/content/catalogs/others/index-leopard-snowleopard.merged-1.sucatalog',
-'http://swscan.apple.com/content/catalogs/others/index-lion-snowleopard-leopard.merged-1.sucatalog'],
+'http://swscan.apple.com/content/catalogs/others/index-lion-snowleopard-leopard.merged-1.sucatalog',
+'http://swscan.apple.com/content/catalogs/others/index-windows-1.sucatalog'],
         'PreferredLocalizations': ['English', 'en'],
         'CurlPath': '/usr/bin/curl'
     }


### PR DESCRIPTION
Added missing urls for 10.4 & windows client support (BootCamp,QuickTime,Bonjour,Iphone,Airport,Itunes,Safari,Updater...)