### PR TITLE
repoutil option to print the contents of the product's .dist file

### DIFF
--- a/code/repoutil
+++ b/code/repoutil
@@ -100,7 +100,23 @@ def get_info(key):
     else:
         reposadocommon.print_stdout('No product id %s found.', key)
 
-
+def get_dist(key):
+	'''Print the .dist file for a specific product for every language in PreferredLocalizations'''
+	products = reposadocommon.getProductInfo()
+	languages = reposadocommon.pref('PreferredLocalizations')
+	if key in products:
+		if products[key].get('CatalogEntry'):
+			if products[key]['CatalogEntry'].get('Distributions'):
+				for lang in languages:
+					if products[key]['CatalogEntry']['Distributions'].get(lang):
+						distPath = reposadocommon.getLocalPathNameFromURL(products[key]['CatalogEntry']['Distributions'][lang])
+						distFd = open(distPath, 'r')
+						distContents = distFd.read()
+						reposadocommon.print_stdout(distContents)
+						distFd.close()
+	else:
+		reposadocommon.print_stdout('No product id %s found.', key)
+		
 def list_branches():
     '''Prints catalog branch names'''
     catalog_branches = reposadocommon.getCatalogBranches()
@@ -382,6 +398,9 @@ def main():
     p.add_option('--product-info', '--info', metavar='PRODUCT_ID',
                     dest='info',
                     help="""Print info on a specific update.""")
+    p.add_option('--product-dist', '--dist', metavar='PRODUCT_ID',
+                    dest='dist',
+                    help="""Print the contents of the .dist file for a specific update.""")
     p.add_option('--add-product', '--add-update', '--add',
                     dest='add_product', nargs=2,
                     metavar='PRODUCT_ID [PRODUCT_ID ...] BRANCH_NAME',
@@ -412,6 +431,8 @@ def main():
         list_branches()
     if options.info:
         get_info(options.info)
+    if options.dist:
+        get_dist(options.dist)
     if options.new_branch:
         new_branch(options.new_branch)
     if options.copy_branch:


### PR DESCRIPTION
Open to feedback on this. I considered folding this into the --info option, but decided to keep it separate as it's a lot of information and mostly useful for knowing about machine-specific updates or other esoteric requirements.

It could also make sense for this to be invoked as an optional flag to --info, ie. "repoutil --info=PRODUCT_ID --dist" But as there aren't other options with optional flags (to my knowledge), maybe it's clearer to keep this as a separate option.

The deep nest of ifs for checking the existence of the product:CatalogEntry:Distributions:[localization] is mostly just my following the logic of get_info() function. It also prints a copy of the dist for every language localization available in the list given in preferences.plist. Reading the .dist is just doing an fd read on the local file, though maybe there are other suggestions for printing the contents.
