### PR TITLE
Symlinks not resolved in get_main_dir(), preferences.plist not found when symlinked.

### DIFF
--- a/code/reposadolib/reposadocommon.py
+++ b/code/reposadolib/reposadocommon.py
@@ -48,17 +48,33 @@ import urlparse
 import warnings
 from xml.parsers.expat import ExpatError
 
-def get_main_dir():
+def get_main_dir(follow_symlinks=False):
     '''Returns the directory name of the script or the directory name of the exe if py2exe was used
     Code from http://www.py2exe.org/index.cgi/HowToDetermineIfRunningFromExe
     '''
     if (hasattr(sys, "frozen") or hasattr(sys, "importers") or imp.is_frozen("__main__")):
         return os.path.dirname(sys.executable)
-    return os.path.dirname(os.path.realpath(sys.argv[0]))
+    path = ''
+    if (follow_symlinks):
+        path = os.path.dirname(os.path.realpath(sys.argv[0]))
+    else:
+        path = os.path.dirname(sys.argv[0])
+    return path
 
 def prefsFilePath():
     '''Returns path to our preferences file.'''
-    return os.path.join(get_main_dir(), 'preferences.plist')
+    prefsFile = ''
+    try:
+        with open(os.path.join(get_main_dir(), 'preferences.plist')) as f: pass
+        prefsFile = os.path.join(get_main_dir(), 'preferences.plist')
+    except IOError as e:
+        try:
+            with open(os.path.join(os.path.realpath(get_main_dir(True)), 'preferences.plist')) as f: pass
+            prefsFile = os.path.join(os.path.realpath(get_main_dir(True)), 'preferences.plist')
+        except IOError as e:
+            pass
+    return prefsFile
+
 
 
 def pref(prefname):


### PR DESCRIPTION
Hi Greg,

When someone installs reposado to, say, /usr/local/reposado then symlinks `repo_sync` and `repoutil` from /usr/bin, reposadocommon.py's `get_main_dir()` doesn't resolve that symlink and looks for preferences.plist in /usr/bin.

I would rather keep everything together and have my preferences.plist file in /usr/local/reposado/code, and only have the two symlinks in /usr/bin.

Easy fix, but it will likely break the configuration for existing reposado installs. I added some ugly logic that will give a preferences.plist file at the unresolved location precedence over one at the resolved path.
