### PR TITLE
Add --no-download and --product-id options to repo_sync

### DIFF
--- a/code/repo_sync
+++ b/code/repo_sync
@@ -597,7 +597,7 @@ def cleanUpTmpDir():
 
 
 TMPDIR = None
-def sync(fast_scan=False, download_packages=True):
+def sync(fast_scan=False, download_packages=True, product_ids=None):
     '''Syncs Apple's Software Updates with our local store.
     Returns a dictionary of products.'''
     global TMPDIR
@@ -607,7 +607,7 @@ def sync(fast_scan=False, download_packages=True):
     reposadocommon.print_stdout('repo_sync run started')
     catalog_urls = reposadocommon.pref('AppleCatalogURLs')
     products = reposadocommon.getProductInfo()
-    
+
     # clear cached AppleCatalog listings
     for item in products.keys():
         products[item]['AppleCatalogs'] = []
@@ -637,6 +637,8 @@ def sync(fast_scan=False, download_packages=True):
                 len(product_keys), catalog_url)
             product_keys.sort()
             for product_key in product_keys:
+                if product_ids and product_key not in product_ids:
+                    continue
                 if product_key in replicated_products:
                     products[product_key]['AppleCatalogs'].append(
                         catalog_url)
@@ -784,13 +786,18 @@ def main():
                  help="""Recheck already downloaded packages for changes.""")
     parser.add_option('--log', dest='logfile', metavar='LOGFILE',
                  help="""Log all output to LOGFILE. No output to STDOUT.""")
+    parser.add_option('--no-download', dest='no_download', action='store_true',
+                 help="""Do not download update packages.""")
+    parser.add_option('--product-id', dest='product_ids', action='append',
+                      metavar='ID',
+                 help="""Only fetch packages with id ID.""")
     options, unused_arguments = parser.parse_args()
     if reposadocommon.validPreferences():
         if not os.path.exists(reposadocommon.pref('CurlPath')):
             reposadocommon.print_stderr('ERROR: curl tool not found at %s',
                 reposadocommon.pref('CurlPath'))
             exit(-1)
-        if not reposadocommon.pref('LocalCatalogURLBase'):
+        if not reposadocommon.pref('LocalCatalogURLBase') or options.no_download:
             download_packages = False
         else:
             download_packages = True
@@ -798,9 +805,15 @@ def main():
             reposadocommon.LOGFILE = options.logfile
         elif reposadocommon.pref('RepoSyncLogFile'):
             reposadocommon.LOGFILE = reposadocommon.pref('RepoSyncLogFile')
-            
-        sync(fast_scan=(not options.recheck), 
-             download_packages=download_packages)
+
+        if options.product_ids:
+            product_ids = set(options.product_ids)
+        else:
+            product_ids = None
+
+        sync(fast_scan=(not options.recheck),
+             download_packages=download_packages,
+             product_ids=product_ids)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I'm writing a tool that needs to get OS X update packages, and Reposado does a great job of that. However, there are a lot of updates advertised by Apple that I don't need, so I added a few options to repo_sync to let me trim down the set of packages it downloads:
* --no-download makes repo_sync download update catalogs but not the update packages
** I use this to fetch the full list of available updates without downloading the actual update packages.
* --product-id allows selecting a specific set of updates to download
** I use this to filter the set of update packages.
