### PR TITLE
config-data to reposadocommon and config-data presence checking

### DIFF
--- a/code/reposadolib/reposadocommon.py
+++ b/code/reposadolib/reposadocommon.py
@@ -504,11 +504,16 @@ def writeXMLtoFile(node, path):
 
 
 def remove_config_data_attribute(product_list):
+    check_or_remove_config_data_attribute(product_list, remove_attr=True)
+
+
+def check_or_remove_config_data_attribute(product_list, remove_attr=False):
     '''Remove the type="config-data" attribute from the distribution options for
     a product. This makes softwareupdate find and display updates like
     XProtectPlistConfigData and Gatekeeper Configuration Data, which it normally
     does not.'''
     products = getProductInfo()
+    config_data_products = set()
     for key in product_list:
         if key in products:
             if products[key].get('CatalogEntry'):
@@ -527,19 +532,20 @@ def remove_config_data_attribute(product_list):
                                 if (element.attributes['type'].value
                                         == 'config-data'):
                                     found_config_data = True
-                                    element.removeAttribute('type')
+                                    config_data_products.add(key)
+                                    if remove_attr:
+                                        element.removeAttribute('type')
                         # done editing dom
-                        if found_config_data:
+                        if found_config_data and remove_attr:
                             try:
                                 writeXMLtoFile(dom, distPath)
                             except (OSError, IOError):
                                 pass
                             else:
-                                print_stdout(
-                                    'Updated dist: %s', distPath)
-                        else:
-                            print_stdout(
-                                'No config-data in %s', distPath)
+                                print_stdout('Updated dist: %s', distPath)
+                        elif not found_config_data:
+                            print_stdout('No config-data in %s', distPath)
+    return list(config_data_products)
 
 LOGFILE = None
 def main():

--- a/code/reposadolib/reposadocommon.py
+++ b/code/reposadolib/reposadocommon.py
@@ -504,14 +504,19 @@ def writeXMLtoFile(node, path):
 
 
 def remove_config_data_attribute(product_list):
+    '''Wrapper to emulate previous behavior of remove-only only operation.'''
     check_or_remove_config_data_attribute(product_list, remove_attr=True)
 
 
 def check_or_remove_config_data_attribute(product_list, remove_attr=False):
-    '''Remove the type="config-data" attribute from the distribution options for
-    a product. This makes softwareupdate find and display updates like
-    XProtectPlistConfigData and Gatekeeper Configuration Data, which it normally
-    does not.'''
+    '''Loop through the type="config-data" attributes from the distribution
+    options for a list of products. Return a list of products that have
+    this attribute set or if `remove_attr` is specified then remove the
+    attribute from the distribution file.
+
+    This makes softwareupdate find and display updates like
+    XProtectPlistConfigData and Gatekeeper Configuration Data, which it
+    normally does not.'''
     products = getProductInfo()
     config_data_products = set()
     for key in product_list:

--- a/code/reposadolib/reposadocommon.py
+++ b/code/reposadolib/reposadocommon.py
@@ -522,6 +522,8 @@ def check_or_remove_config_data_attribute(product_list, remove_attr=False):
                 for lang in distributions.keys():
                     distPath = getLocalPathNameFromURL(
                         products[key]['CatalogEntry']['Distributions'][lang])
+                    if not os.path.exists(distPath):
+                        continue
                     dom = readXMLfile(distPath)
                     if dom:
                         found_config_data = False

--- a/code/repoutil
+++ b/code/repoutil
@@ -39,8 +39,6 @@ Apple Software Update server'''
 import optparse
 import os
 import shutil
-from xml.dom import minidom
-from xml.parsers.expat import ExpatError
 
 from reposadolib import reposadocommon
 
@@ -162,71 +160,6 @@ def print_info(key):
         reposadocommon.print_stdout(product.get('description'))
     else:
         reposadocommon.print_stdout('No product id %s found.', key)
-
-
-def readXMLfile(filename):
-    '''Return dom from XML file or None'''
-    try:
-        dom = minidom.parse(filename)
-    except ExpatError:
-        reposadocommon.print_stderr(
-            'Invalid XML in %s', filename)
-        return None
-    except IOError, err:
-        reposadocommon.print_stderr(
-            'Error reading %s: %s', filename, err)
-        return None
-    return dom
-
-
-def writeXMLtoFile(node, path):
-    '''Write XML dom node to file'''
-    xml_string = node.toxml()
-    try:
-        fileobject = open(path, mode='w')
-        print >> fileobject, xml_string
-        fileobject.close()
-    except (OSError, IOError):
-        reposadocommon.print_stderr('Couldn\'t write XML to %s' % path)
-
-
-def remove_config_data_attribute(product_list):
-    '''Remove the type="config-data" attribute from the distribution options for
-    a product. This makes softwareupdate find and display updates like
-    XProtectPlistConfigData and Gatekeeper Configuration Data, which it normally
-    does not.'''
-    products = reposadocommon.getProductInfo()
-    for key in product_list:
-        if key in products:
-            if products[key].get('CatalogEntry'):
-                distributions = products[key]['CatalogEntry'].get(
-                    'Distributions', {})
-                for lang in distributions.keys():
-                    distPath = reposadocommon.getLocalPathNameFromURL(
-                        products[key]['CatalogEntry']['Distributions'][lang])
-                    dom = readXMLfile(distPath)
-                    if dom:
-                        found_config_data = False
-                        option_elements = (
-                            dom.getElementsByTagName('options') or [])
-                        for element in option_elements:
-                            if 'type' in element.attributes.keys():
-                                if (element.attributes['type'].value
-                                        == 'config-data'):
-                                    found_config_data = True
-                                    element.removeAttribute('type')
-                        # done editing dom
-                        if found_config_data:
-                            try:
-                                writeXMLtoFile(dom, distPath)
-                            except (OSError, IOError):
-                                pass
-                            else:
-                                reposadocommon.print_stdout(
-                                    'Updated dist: %s', distPath)
-                        else:
-                            reposadocommon.print_stdout(
-                                'No config-data in %s', distPath)
 
 
 def print_dist(key):
@@ -755,7 +688,7 @@ def main():
     if options.remove_config_data:
         params = [options.remove_config_data]
         params.extend(arguments)
-        remove_config_data_attribute(params)
+        reposadocommon.remove_config_data_attribute(params)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
These commits move the config-data attribute modification to `reposadocommon` from `repoutil` and implement mere checking for (and not necessarily removing of) config-data presence in the language distribution files. Both of these changes are to support 3rd party tools using and interacting with that data via `import reposadocommon`.