### PR TITLE
Docs fixes and tweaks

### DIFF
--- a/docs/client_configuration.md
+++ b/docs/client_configuration.md
@@ -77,3 +77,25 @@ Mavericks clients should use a CatalogURL of the form:
 Branch CatalogURLs take the form of:
 
     http://su.yourorg.com/content/catalogs/others/index-10.9-mountainlion-lion-snowleopard-leopard.merged-1_<branchname>.sucatalog
+
+
+## Yosemite Clients
+
+Yosemite clients should use a CatalogURL of the form:
+
+    http://su.yourorg.com/content/catalogs/others/index-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog
+
+Branch CatalogURLs take the form of:
+
+    http://su.yourorg.com/content/catalogs/others/index-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1_<branchname>.sucatalog
+
+
+## El Capitan Clients
+
+El Capitan clients should use a CatalogURL of the form:
+
+    http://su.yourorg.com/content/catalogs/others/index-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog
+
+Branch CatalogURLs take the form of:
+
+    http://su.yourorg.com/content/catalogs/others/index-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1_<branchname>.sucatalog

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -3,8 +3,8 @@
 What you need:
 
 - The Reposado tools
-- Python 2.5-2.7 with plistlib. (Reposado has been tested with Python 2.6, but should work with 2.5-2.7 as long as plistlib is available. plistlib was included as a Mac-specific library with Python 2.5, and for all platforms with Python 2.6.)
-- curl binary
+- Python 2.5-2.7 with *plistlib*. (Reposado has been tested with Python 2.6, but should work with 2.5-2.7 as long as *plistlib* is available. *plistlib* was included as a Mac-specific library with Python 2.5, and for all platforms with Python 2.6.)
+- *curl* binary
 - A web server
 - Storage space for the catalogs and update packages. If you are replicating the update packages, you'll need approximately 120GB of space as of October 2012. The need for space grows as additional updates are released by Apple. If you are only replicating catalogs, you'll probably need less than 100MB of space, though the exact amount of space needed depends on the number of branch catalogs you create.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -26,7 +26,7 @@ Specify a log file to redirect all output to.
 	
 	repoutil --configure
 
-Configure key preferences for Reposado. Note this command does not allow you to edit all available Reposado preferences. See reposado_preferences.txt for more information.
+Configure key preferences for Reposado. Note this command does not allow you to edit all available Reposado preferences. See [reposado_preferences](./reposado_preferences.md) for more information.
 
 
 ### LISTING AVAILABLE PRODUCTS (UPDATES)

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -164,7 +164,7 @@ You may add all cached products, including deprecated products to a branch catal
 	
 	repoutil --remove-product=PRODUCT_ID [PRODUCT_ID ...] BRANCH_NAME
 	                        
-	Remove one or more PRODUCT_IDs from catalog branch BRANCH_NAME.
+Remove one or more PRODUCT_IDs from catalog branch BRANCH_NAME.
 
 
 ### PURGING PRODUCTS ENTIRELY

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -57,7 +57,11 @@ Example:
                         
 List deprecated updates. These are updates that are no longer available from Apple. 
 They may have been withdrawn, or have been superseded by newer versions. Example:
-<to be generated>
+
+	repoutil --deprecated
+	031-41757       Digital Camera RAW Compatibility Update            6.17       2015-10-19 ['testing'] (Deprecated)
+	031-34805       Safari                                             9.0.1      2015-10-21 ['testing'] (Deprecated)
+	zzzz031-36002   iTunes                                             12.3.1     2015-10-21 ['testing'] (Deprecated)
 
 
 ### LISTING AVAILABLE BRANCH CATALOGS


### PR DESCRIPTION
Few things I missed in last pull request.

Fixed one missing link and indent in reference.md. Also added missing example for repoutil --deprecated.

Added Yosemite and El Capitan URLs to client_configuration.md.

Added italics formatting for curl and plistlib in getting_started.md