### PR TITLE
Add option to list all updates of type "config-data"  

### DIFF
--- a/code/repoutil
+++ b/code/repoutil
@@ -284,6 +284,16 @@ def list_deprecated(sort_order='date', reverse_sort=False):
     list_products(sort_order, reverse_sort, list_of_productids)
 
 
+def list_config_data(sort_order='date', reverse_sort=False):
+    '''Find updates with \'type="config-data"\' attribute'''
+    product_info = reposadocommon.getProductInfo()
+    product_list = product_info.keys()
+    matching_products = reposadocommon.check_or_remove_config_data_attribute(
+        product_list, remove_attr=False, products=product_info,
+        suppress_output=True)
+    list_products(sort_order, reverse_sort, matching_products)
+
+
 def list_products(sort_order='date', reverse_sort=False,
                   list_of_productids=None):
     '''Prints a list of Software Update products'''
@@ -615,6 +625,8 @@ def main():
                  help="""List available updates""")
     p.add_option('--deprecated', action='store_true',
                  help="""List deprecated updates""")
+    p.add_option('--config-data', action='store_true',
+                 help="""List updates with 'type="config-data"' attribute""")
     p.add_option('--sort', metavar='SORT_ORDER', default='date',
                  help="""Sort list.
                  Available sort orders are: date, title, id""")
@@ -681,6 +693,8 @@ def main():
         list_products(sort_order=options.sort, reverse_sort=options.reverse)
     if options.deprecated:
         list_deprecated(sort_order=options.sort, reverse_sort=options.reverse)
+    if options.config_data:
+        list_config_data(sort_order=options.sort, reverse_sort=options.reverse)
     if options.branch:
         list_branch(options.branch, sort_order=options.sort,
                     reverse_sort=options.reverse)

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -63,6 +63,19 @@ They may have been withdrawn, or have been superseded by newer versions. Example
 	031-34805       Safari                                             9.0.1      2015-10-21 ['testing'] (Deprecated)
 	zzzz031-36002   iTunes                                             12.3.1     2015-10-21 ['testing'] (Deprecated)
 
+### LISTING CRITICAL UPDATES
+	
+	repoutil --config-data
+                        
+List critical updates. These are updates that are marked as "config-data" by Apple. 
+Depending on the setting on the client, those updates can be automatically installed without 
+any user interaction.
+
+	repoutil --config-data
+	031-12170       Gatekeeper Configuration Data                      1.0        2015-02-09 ['testing'] 
+	031-38723       XProtectPlistConfigData                            1.0        2015-10-19 [] (Deprecated)
+	031-52942       XProtectPlistConfigData                            1.0        2016-03-05 ['testing'] 
+
 
 ### LISTING AVAILABLE BRANCH CATALOGS
 	


### PR DESCRIPTION
Just as --remove-config-data removes the attribute from the dist files, this patch will just list those updates. This allows for easy differentiation between the other updates.
As this goes through every .dist file, the option is a bit on the slow side. I have experimented with storing the config-data attribute inside reposado's metadata, but that would make everything more complicated (while being only 4x as fast).