### PR TITLE
Manage deprecated products on a branch.

### DIFF
--- a/code/repoutil
+++ b/code/repoutil
@@ -284,6 +284,14 @@ def list_deprecated(sort_order='date', reverse_sort=False):
     list_products(sort_order, reverse_sort, list_of_productids)
 
 
+def list_non_deprecated(sort_order='date', reverse_sort=False):
+    '''Find products that are referenced in Apple\'s catalogs'''
+    products = reposadocommon.getProductInfo()
+    list_of_productids = [key for key in products.keys()
+                          if products[key].get('AppleCatalogs')]
+    list_products(sort_order, reverse_sort, list_of_productids)
+
+
 def list_products(sort_order='date', reverse_sort=False,
                   list_of_productids=None):
     '''Prints a list of Software Update products'''
@@ -623,6 +631,8 @@ def main():
                  help="""List available updates""")
     p.add_option('--deprecated', action='store_true',
                  help="""List deprecated updates""")
+    p.add_option('--non-deprecated', action='store_true',
+                 help="""List non-deprecated updates""")
     p.add_option('--sort', metavar='SORT_ORDER', default='date',
                  help="""Sort list.
                  Available sort orders are: date, title, id""")
@@ -689,6 +699,8 @@ def main():
         list_products(sort_order=options.sort, reverse_sort=options.reverse)
     if options.deprecated:
         list_deprecated(sort_order=options.sort, reverse_sort=options.reverse)
+    if options.non_deprecated:
+        list_non_deprecated(sort_order=options.sort, reverse_sort=options.reverse)
     if options.branch:
         list_branch(options.branch, sort_order=options.sort,
                     reverse_sort=options.reverse)

--- a/code/repoutil
+++ b/code/repoutil
@@ -426,20 +426,20 @@ def remove_product_from_branch(parameters):
     branch_name = parameters[-1]
     product_id_list = parameters[0:-1]
 
-    if 'deprecated' in product_id_list:
-        products = reposadocommon.getProductInfo()
-        product_id_list = [key for key in products.keys()
-                           if not products[key].get('AppleCatalogs')]
-    else:
-        # remove all duplicate product ids
-        product_id_list = list(set(product_id_list))
-
     catalog_branches = reposadocommon.getCatalogBranches()
     if not branch_name in catalog_branches:
         reposadocommon.print_stderr(
             'Catalog branch %s doesn\'t exist!', branch_name)
         return
+
     products = reposadocommon.getProductInfo()
+    if 'deprecated' in product_id_list:
+        product_id_list = [key for key in catalog_branches[branch_name]
+                           if not products[key].get('AppleCatalogs')]
+    else:
+        # remove all duplicate product ids
+        product_id_list = list(set(product_id_list))
+
     for product_id in product_id_list:
         if product_id in products:
             title = products[product_id].get('title')

--- a/code/repoutil
+++ b/code/repoutil
@@ -358,6 +358,9 @@ def add_product_to_branch(parameters):
     products = reposadocommon.getProductInfo()
     if 'all' in product_id_list:
         product_id_list = products.keys()
+    elif 'non-deprecated' in product_id_list:
+        product_id_list = [key for key in products.keys()
+                           if products[key].get('AppleCatalogs')]
 
     for product_id in product_id_list:
         if not product_id in products:
@@ -405,8 +408,13 @@ def remove_product_from_branch(parameters):
     branch_name = parameters[-1]
     product_id_list = parameters[0:-1]
 
-    # remove all duplicate product ids
-    product_id_list = list(set(product_id_list))
+    if 'deprecated' in product_id_list:
+        products = reposadocommon.getProductInfo()
+        product_id_list = [key for key in products.keys()
+                           if not products[key].get('AppleCatalogs')]
+    else:
+        # remove all duplicate product ids
+        product_id_list = list(set(product_id_list))
 
     catalog_branches = reposadocommon.getCatalogBranches()
     if not branch_name in catalog_branches:

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -54,8 +54,9 @@ Example:
 ### LISTING DEPRECATED UPDATES
 	
 	repoutil --deprecated
+	repoutil --non-deprecated
                         
-List deprecated updates. These are updates that are no longer available from Apple. 
+List deprecated or non-deprecated updates. Deprecated products are updates that are no longer available from Apple. 
 They may have been withdrawn, or have been superseded by newer versions. Example:
 
 	repoutil --deprecated
@@ -159,8 +160,9 @@ Prints detailed info on a specific update. Example:
 	repoutil --add=PRODUCT_ID [PRODUCT_ID ...] BRANCH_NAME
                         
 Add one or more PRODUCT_IDs to catalog branch BRANCH_NAME.
-You may add all cached products, including deprecated products to a branch catalog by specifying 'all':
+You may add all cached products, optionally including deprecated products to a branch catalog by specifying 'non-deprecated' or 'all':
 
+	repoutil --add-product non-deprecated BRANCH_NAME
 	repoutil --add-product all BRANCH_NAME
 
 
@@ -168,7 +170,9 @@ You may add all cached products, including deprecated products to a branch catal
 	
 	repoutil --remove-product=PRODUCT_ID [PRODUCT_ID ...] BRANCH_NAME
 	                        
-Remove one or more PRODUCT_IDs from catalog branch BRANCH_NAME.
+Remove one or more PRODUCT_IDs from catalog branch BRANCH_NAME. You may remove all deprecated products from a branch by specifying 'deprecated':
+
+	repoutil --remove-product deprecated BRANCH_NAME
 
 
 ### PURGING PRODUCTS ENTIRELY


### PR DESCRIPTION
I'm sharing a reposado server with someone who needs to keep deprecated products around, while I'm mainly interested in mirroring the latest Apple catalog. I'm too lazy to selectively add products, and adding all to my branch brings in all the deprecated products. Thus:

    repoutil --remove-product deprecated BRANCH
    repoutil --add-product non-deprecated BRANCH

This makes it easier to follow the current Apple catalog while still keeping deprecated products.