### PR TITLE
Fix macOS Sierra default CatalogURL

### DIFF
--- a/code/reposadolib/reposadocommon.py
+++ b/code/reposadolib/reposadocommon.py
@@ -90,7 +90,7 @@ def pref(prefname):
              'index-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard'
              '.merged-1.sucatalog'),
             ('https://swscan.apple.com/content/catalogs/others/'
-             'index-10-12-10.11-10.10-10.9-mountainlion-lion-snowleopard-'
+             'index-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-'
              'leopard.merged-1.sucatalog')
         ],
         'PreferredLocalizations': ['English', 'en'],


### PR DESCRIPTION
d3dd0a0bac408395a04f4325060e9b52fe15c684 adds the URL to the code and the documentation, but the one in the code is wrong and just results in a HTTP 404 error.