### PR TITLE
Compression for sucatalog files

### DIFF
--- a/code/repo_sync
+++ b/code/repo_sync
@@ -488,7 +488,6 @@ class ReplicationError(Exception):
     '''A custom error when replication fails'''
     pass
 
-
 def replicateURLtoFilesystem(full_url, root_dir=None,
                              base_url=None, copy_only_if_missing=False,
                              appendToFilename=''):
@@ -511,6 +510,7 @@ def replicateURLtoFilesystem(full_url, root_dir=None,
     local_file_path = os.path.join(root_dir, relative_url) + appendToFilename
     local_dir_path = os.path.dirname(local_file_path)
     if copy_only_if_missing and os.path.exists(local_file_path):
+        reposadocommon.createCompressedFileCopy(local_file_path, True)
         return local_file_path
     if not os.path.exists(local_dir_path):
         try:
@@ -521,6 +521,7 @@ def replicateURLtoFilesystem(full_url, root_dir=None,
         getURL(full_url, local_file_path)
     except CurlDownloadError, err:
         raise ReplicationError(err)
+    reposadocommon.createCompressedFileCopy(local_file_path)
     return local_file_path
 
 

--- a/code/reposadolib/reposadocommon.py
+++ b/code/reposadolib/reposadocommon.py
@@ -258,6 +258,12 @@ def getDataFromPlist(filename):
     except (IOError, ExpatError):
         return {}
 
+def createCompressedFileCopy(local_file_path, copy_only_if_missing=False):
+    '''creates a gzipped copy of the given file at the same location with .gz suffix'''
+    local_gz_file_path = local_file_path + '.gz'
+    if not ( copy_only_if_missing and os.path.exists(local_gz_file_path)):
+	    with open(local_file_path) as f_in, gzip.open(local_gz_file_path, 'wb') as f_out:
+   		    f_out.writelines(f_in)
 
 def getDownloadStatus():
     '''Reads download status info from disk'''
@@ -431,8 +437,7 @@ def writeBranchCatalogs(localcatalogpath):
                         product_key, branch, localcatalogname)
 
         plistlib.writePlist(catalog, branchcatalogpath)
-        with open(branchcatalogpath) as f_in, gzip.open(branchcatalogpath + '.gz', 'wb') as f_out:
-            f_out.writelines(f_in)
+        createCompressedFileCopy(branchcatalogpath)
 
 def writeAllLocalCatalogs():
     '''Writes out all local and branch catalogs. Used when we purge products.'''
@@ -474,8 +479,7 @@ def writeLocalCatalogs(applecatalogpath):
     # write raw (unstable/development) catalog
     # with all downloaded Apple updates enabled
     plistlib.writePlist(catalog, localcatalogpath)
-    with open(localcatalogpath) as f_in, gzip.open(localcatalogpath + '.gz', 'wb') as f_out:
-        f_out.writelines(f_in)
+    createCompressedFileCopy(localcatalogpath)
 
     # now write filtered catalogs (branches) based on this catalog
     writeBranchCatalogs(localcatalogpath)

--- a/code/reposadolib/reposadocommon.py
+++ b/code/reposadolib/reposadocommon.py
@@ -262,7 +262,7 @@ def createCompressedFileCopy(local_file_path, copy_only_if_missing=False):
     '''creates a gzipped copy of the given file at the same location with .gz suffix'''
     local_gz_file_path = local_file_path + '.gz'
     if not ( copy_only_if_missing and os.path.exists(local_gz_file_path)):
-	    with open(local_file_path) as f_in, gzip.open(local_gz_file_path, 'wb') as f_out:
+	    with open(local_file_path) as f_in, gzip.open(local_gz_file_path, 'w') as f_out:
    		    f_out.writelines(f_in)
 
 def getDownloadStatus():

--- a/code/reposadolib/reposadocommon.py
+++ b/code/reposadolib/reposadocommon.py
@@ -46,6 +46,7 @@ import plistlib
 import time
 import urlparse
 import warnings
+import gzip
 from xml.parsers.expat import ExpatError
 from xml.dom import minidom
 
@@ -430,7 +431,8 @@ def writeBranchCatalogs(localcatalogpath):
                         product_key, branch, localcatalogname)
 
         plistlib.writePlist(catalog, branchcatalogpath)
-
+        with open(branchcatalogpath) as f_in, gzip.open(branchcatalogpath + '.gz', 'wb') as f_out:
+            f_out.writelines(f_in)
 
 def writeAllLocalCatalogs():
     '''Writes out all local and branch catalogs. Used when we purge products.'''
@@ -472,6 +474,8 @@ def writeLocalCatalogs(applecatalogpath):
     # write raw (unstable/development) catalog
     # with all downloaded Apple updates enabled
     plistlib.writePlist(catalog, localcatalogpath)
+    with open(localcatalogpath) as f_in, gzip.open(localcatalogpath + '.gz', 'wb') as f_out:
+        f_out.writelines(f_in)
 
     # now write filtered catalogs (branches) based on this catalog
     writeBranchCatalogs(localcatalogpath)

--- a/docs/URL_rewrites.md
+++ b/docs/URL_rewrites.md
@@ -17,9 +17,13 @@ If you are using Apache2 as your webserver, you may be able to configure mod_rew
 
 Here is an example .htaccess file you could place at the root of your Reposado repo:
 
+        AddEncoding x-gzip .gz
+        AddType text/plain .gz
 		Options FollowSymLinks
 		RewriteEngine On
 		RewriteBase /
+		RewriteCond %{HTTP_USER_AGENT} Darwin/16
+		RewriteRule ^/index(.*)\.sucatalog(\.gz)?$ /content/catalogs/others/index-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1$1.sucatalog$2 [S=8]
 		RewriteCond %{HTTP_USER_AGENT} Darwin/15
 		RewriteRule ^/index(.*)\.sucatalog(\.gz)?$ /content/catalogs/others/index-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1$1.sucatalog$2 [S=7]
 		RewriteCond %{HTTP_USER_AGENT} Darwin/14

--- a/docs/URL_rewrites.md
+++ b/docs/URL_rewrites.md
@@ -20,6 +20,8 @@ Here is an example .htaccess file you could place at the root of your Reposado r
 	RewriteEngine On
 	Options FollowSymLinks
 	RewriteBase  /
+	RewriteCond %{HTTP:Accept-Encoding} gzip
+	RewriteRule ^(.+\.(sucatalog))$ /$1.gz [L]
 	RewriteCond %{HTTP_USER_AGENT} Darwin/8
 	RewriteRule ^index(.*)\.sucatalog$ content/catalogs/index$1.sucatalog [L]
 	RewriteCond %{HTTP_USER_AGENT} Darwin/9

--- a/docs/URL_rewrites.md
+++ b/docs/URL_rewrites.md
@@ -17,28 +17,28 @@ If you are using Apache2 as your webserver, you may be able to configure mod_rew
 
 Here is an example .htaccess file you could place at the root of your Reposado repo:
 
-	RewriteEngine On
-	Options FollowSymLinks
-	RewriteBase  /
-    RewriteCond %{HTTP:Accept-Encoding} gzip
-    RewriteRule ^(.+\.(sucatalog|dist))$ /$1.gz [L]
-	RewriteCond %{HTTP_USER_AGENT} Darwin/8
-	RewriteRule ^index(.*)\.sucatalog$ content/catalogs/index$1.sucatalog [L]
-	RewriteCond %{HTTP_USER_AGENT} Darwin/9
-	RewriteRule ^index(.*)\.sucatalog$ content/catalogs/others/index-leopard.merged-1$1.sucatalog [L]
-	RewriteCond %{HTTP_USER_AGENT} Darwin/10
-	RewriteRule ^index(.*)\.sucatalog$ content/catalogs/others/index-leopard-snowleopard.merged-1$1.sucatalog [L]
-	RewriteCond %{HTTP_USER_AGENT} Darwin/11
-	RewriteRule ^index(.*)\.sucatalog$ content/catalogs/others/index-lion-snowleopard-leopard.merged-1$1.sucatalog [L]
-	RewriteCond %{HTTP_USER_AGENT} Darwin/12
-	RewriteRule ^index(.*)\.sucatalog$ content/catalogs/others/index-mountainlion-lion-snowleopard-leopard.merged-1$1.sucatalog [L]
-	RewriteCond %{HTTP_USER_AGENT} Darwin/13
-	RewriteRule ^index(.*)\.sucatalog$ content/catalogs/others/index-10.9-mountainlion-lion-snowleopard-leopard.merged-1$1.sucatalog [L]
-	RewriteCond %{HTTP_USER_AGENT} Darwin/14
-	RewriteRule ^index(.*)\.sucatalog$ content/catalogs/others/index-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1$1.sucatalog [L]
-	RewriteCond %{HTTP_USER_AGENT} Darwin/15
-	RewriteRule ^index(.*)\.sucatalog$ content/catalogs/others/index-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1$1.sucatalog [L]
-
+		Options FollowSymLinks
+		RewriteEngine On
+		RewriteBase /
+		RewriteCond %{HTTP_USER_AGENT} Darwin/15
+		RewriteRule ^/index(.*)\.sucatalog(\.gz)?$ /content/catalogs/others/index-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1$1.sucatalog$2 [S=7]
+		RewriteCond %{HTTP_USER_AGENT} Darwin/14
+		RewriteRule ^/index(.*)\.sucatalog(\.gz)?$ /content/catalogs/others/index-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1$1.sucatalog$2 [S=6]
+		RewriteCond %{HTTP_USER_AGENT} Darwin/13
+		RewriteRule ^/index(.*)\.sucatalog(\.gz)?$ /content/catalogs/others/index-10.9-mountainlion-lion-snowleopard-leopard.merged-1$1.sucatalog$2 [S=5]
+		RewriteCond %{HTTP_USER_AGENT} Darwin/12
+		RewriteRule ^/index(.*)\.sucatalog(\.gz)?$ /content/catalogs/others/index-mountainlion-lion-snowleopard-leopard.merged-1$1.sucatalog$2 [S=4]
+		RewriteCond %{HTTP_USER_AGENT} Darwin/11
+		RewriteRule ^/index(.*)\.sucatalog(\.gz)?$ /content/catalogs/others/index-lion-snowleopard-leopard.merged-1$1.sucatalog$2 [S=3]
+		RewriteCond %{HTTP_USER_AGENT} Darwin/10
+		RewriteRule ^/index(.*)\.sucatalog(\.gz)?$ /content/catalogs/others/index-leopard-snowleopard.merged-1$1.sucatalog$2 [S=2]
+		RewriteCond %{HTTP_USER_AGENT} Darwin/9
+		RewriteRule ^/index(.*)\.sucatalog(\.gz)?$ /content/catalogs/others/index-leopard.merged-1$1.sucatalog$2 [S=1]
+		RewriteCond %{HTTP_USER_AGENT} Darwin/8
+		RewriteRule ^/index(.*)\.sucatalog(\.gz)?$ /content/catalogs/index$1.sucatalog
+		RewriteCond %{HTTP:Accept-Encoding} gzip
+		RewriteRule ^(.+\.(sucatalog|dist))$ $1.gz
+ 
 
 This requires Apache2 to be configured to actually pay attention to mod_rewrite rules in .htaccess files. See your Apache and mod_rewrite documentation for details.
 

--- a/docs/URL_rewrites.md
+++ b/docs/URL_rewrites.md
@@ -20,8 +20,8 @@ Here is an example .htaccess file you could place at the root of your Reposado r
 	RewriteEngine On
 	Options FollowSymLinks
 	RewriteBase  /
-	RewriteCond %{HTTP:Accept-Encoding} gzip
-	RewriteRule ^(.+\.(sucatalog))$ /$1.gz [L]
+    RewriteCond %{HTTP:Accept-Encoding} gzip
+    RewriteRule ^(.+\.(sucatalog|dist))$ /$1.gz [L]
 	RewriteCond %{HTTP_USER_AGENT} Darwin/8
 	RewriteRule ^index(.*)\.sucatalog$ content/catalogs/index$1.sucatalog [L]
 	RewriteCond %{HTTP_USER_AGENT} Darwin/9


### PR DESCRIPTION
The softwareupdate framework can handle gzip compressed sucatalogs, and indicates this by sending an "Accept-Encoding: gzip, deflate" to the server. This reduces network load and speeds up process of checking for new software.

My modifications create a compressed copy of every catalog, as well as of all .dist files, which do compress very well. The compressed versions are saved in the same file system location as the normal ones. Creating static gzipped files needs a little more disk space, but this should be preferred over on-the-fly encoding and its associated CPU cost, because a lot of clients will request the same file.

When using apache, you can now adapt the Rewrite rules to optionally serve the gzipped file version if the client is capable of receiving it. To allow proper processing, the server also needs to send the Content-Encoding: gzip and Content-Type: text/plain headers.
