### PR TITLE
This commit adds a simple check to see if curl is build against NSS.

### DIFF
--- a/code/repo_sync
+++ b/code/repo_sync
@@ -260,17 +260,6 @@ class CurlDownloadError(Exception):
     """Curl failed to download the item"""
     pass
 
-def curl_build_against_NSS():
-    """Check if Curl is build against NSS"""
-    cmd = ['curl', '--version']
-    out = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
-    if out.find('NSS'):
-        curlNSS = True
-    else:
-        curlNSS = False
-
-    return curlNSS
-
 
 
 def curl(url, destinationpath, onlyifnewer=False, etag=None, resume=False):
@@ -295,7 +284,7 @@ def curl(url, destinationpath, onlyifnewer=False, etag=None, resume=False):
 
     curldirectivepath = os.path.join(TMPDIR, 'curl_temp')
     tempdownloadpath = os.path.normpath(destinationpath + '.download')
-    curlNSS = curl_build_against_NSS()
+
     # we're writing all the curl options to a file and passing that to
     # curl so we avoid the problem of URLs showing up in a process listing
     try:
@@ -306,12 +295,7 @@ def curl(url, destinationpath, onlyifnewer=False, etag=None, resume=False):
         print >> fileobj, 'fail'           # throw error if download fails
         print >> fileobj, 'dump-header -'  # dump headers to stdout
         print >> fileobj, 'speed-time = 30' # give up if too slow d/l
-        # next line does not work on windows
-        #print >> fileobj, 'output = "%s"' % tempdownloadpath
-        if curlNSS:
-            print >> fileobj, 'ciphers = rsa_aes_128_gcm_sha_256' # This is used by Apple, should be a longer list...
-        else:
-            print >> fileobj, 'ciphers = HIGH,!ADH' # use only >=128 bit SSL
+        print >> fileobj, 'tlsv1'          # use only TLS 1.x
         print >> fileobj, 'url = "%s"' % url
 
         # add additional options from our prefs

--- a/code/repo_sync
+++ b/code/repo_sync
@@ -260,6 +260,19 @@ class CurlDownloadError(Exception):
     """Curl failed to download the item"""
     pass
 
+def curl_build_against_NSS():
+    """Check if Curl is build against NSS"""
+    cmd = ['curl', '--version']
+    runcmd = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    out, err = runcmd.communicate()
+    if out.find('NSS'):
+        curlNSS = True
+    else:
+        curlNSS = False
+
+    return curlNSS
+
+
 
 def curl(url, destinationpath, onlyifnewer=False, etag=None, resume=False):
     """Gets an HTTP or HTTPS URL and stores it in
@@ -283,7 +296,7 @@ def curl(url, destinationpath, onlyifnewer=False, etag=None, resume=False):
 
     curldirectivepath = os.path.join(TMPDIR, 'curl_temp')
     tempdownloadpath = os.path.normpath(destinationpath + '.download')
-
+    curlNSS = curl_build_against_NSS()
     # we're writing all the curl options to a file and passing that to
     # curl so we avoid the problem of URLs showing up in a process listing
     try:
@@ -296,8 +309,10 @@ def curl(url, destinationpath, onlyifnewer=False, etag=None, resume=False):
         print >> fileobj, 'speed-time = 30' # give up if too slow d/l
         # next line does not work on windows
         #print >> fileobj, 'output = "%s"' % tempdownloadpath
-
-        print >> fileobj, 'ciphers = HIGH,!ADH' # use only >=128 bit SSL
+        if curlNSS:
+            print >> fileobj, 'ciphers = rsa_aes_128_gcm_sha_256' # This is used by Apple, should be a longer list...
+        else:
+            print >> fileobj, 'ciphers = HIGH,!ADH' # use only >=128 bit SSL
         print >> fileobj, 'url = "%s"' % url
 
         # add additional options from our prefs
@@ -835,4 +850,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
 Curl built against NSS has an effect on how cipher suites are handled in curl, i.e. NSS requires different syntax on cipher suites. I've only included the current cipher suite used by Apple, but the list could be longer.

I encountered this issue on:
`Linux our.reposado.server 2.6.32-642.3.1.el6.i686 #1 SMP Sun Jun 26 18:18:18 EDT 2016 i686 i686 i386 GNU/Linux`
curl version:
`curl 7.19.7 (i686-redhat-linux-gnu) libcurl/7.19.7 NSS/3.19.1 Basic ECC zlib/1.2.3 libidn/1.18 libssh2/1.4.2`
