### PR TITLE
adding --force options for copying and deleting branches. 

### DIFF
--- a/code/reposadolib/reposadocommon.py
+++ b/code/reposadolib/reposadocommon.py
@@ -94,8 +94,7 @@ def pref(prefname):
              'leopard.merged-1.sucatalog')
         ],
         'PreferredLocalizations': ['English', 'en'],
-        'CurlPath': '/usr/bin/curl',
-        'PromptForBranchCopies': True
+        'CurlPath': '/usr/bin/curl'
     }
     try:
         prefs = plistlib.readPlist(prefsFilePath())
@@ -435,7 +434,7 @@ def writeBranchCatalogs(localcatalogpath):
                             catalog['Products'][product_key] = catalog_entry
                             continue
             else:
-                if pref('LocalCatalogURLBase') :
+                if pref('LocalCatalogURLBase'):
                     print_stderr(
                         'WARNING: Product %s not added to branch %s of %s. '
                         'It is not in the corresponding Apple catalogs '

--- a/code/reposadolib/reposadocommon.py
+++ b/code/reposadolib/reposadocommon.py
@@ -94,7 +94,8 @@ def pref(prefname):
              'leopard.merged-1.sucatalog')
         ],
         'PreferredLocalizations': ['English', 'en'],
-        'CurlPath': '/usr/bin/curl'
+        'CurlPath': '/usr/bin/curl',
+        'PromptForBranchCopies': True
     }
     try:
         prefs = plistlib.readPlist(prefsFilePath())

--- a/code/repoutil
+++ b/code/repoutil
@@ -547,7 +547,8 @@ def copy_branches(source_branch, dest_branch):
     if not source_branch in catalog_branches:
         reposadocommon.print_stderr('Branch %s does not exist!', source_branch)
         return
-    if dest_branch in catalog_branches:
+    if dest_branch in catalog_branches and reposadocommon.pref(
+            'PromptForBranchCopies'):
         answer = raw_input(
             'Really replace contents of branch %s with branch %s? [y/n] '
             % (dest_branch, source_branch))

--- a/code/repoutil
+++ b/code/repoutil
@@ -534,7 +534,7 @@ def purge_product(product_ids, force=False):
     reposadocommon.writeAllLocalCatalogs()
 
 
-def copy_branches(source_branch, dest_branch):
+def copy_branches(source_branch, dest_branch, force=False):
     '''Copies source_branch to dest_branch, replacing dest_branch'''
     # sanity checking
     for branch in [source_branch, dest_branch]:
@@ -547,8 +547,7 @@ def copy_branches(source_branch, dest_branch):
     if not source_branch in catalog_branches:
         reposadocommon.print_stderr('Branch %s does not exist!', source_branch)
         return
-    if dest_branch in catalog_branches and reposadocommon.pref(
-            'PromptForBranchCopies'):
+    if dest_branch in catalog_branches and not force:
         answer = raw_input(
             'Really replace contents of branch %s with branch %s? [y/n] '
             % (dest_branch, source_branch))
@@ -561,11 +560,16 @@ def copy_branches(source_branch, dest_branch):
     reposadocommon.writeAllBranchCatalogs()
 
 
-def delete_branch(branchname):
+def delete_branch(branchname, force=False):
     '''Deletes a branch'''
     catalog_branches = reposadocommon.getCatalogBranches()
     if not branchname in catalog_branches:
         reposadocommon.print_stderr('Branch %s does not exist!', branchname)
+        return
+    if force:
+        del catalog_branches[branchname]
+        deleteBranchCatalogs(branchname)
+        reposadocommon.writeCatalogBranches(catalog_branches)
         return
     answer = raw_input('Really remove branch %s? [y/n] ' % branchname)
     if answer.lower().startswith('y'):
@@ -644,10 +648,10 @@ def main():
                  metavar='BRANCH_NAME',
                  help='Create new empty branch BRANCH_NAME.')
     p.add_option('--delete-branch',
-                 metavar='BRANCH_NAME',
+                 metavar='BRANCH_NAME [--force]',
                  help='Delete branch BRANCH_NAME.')
     p.add_option('--copy-branch', nargs=2,
-                 metavar='SOURCE_BRANCH DEST_BRANCH',
+                 metavar='SOURCE_BRANCH DEST_BRANCH [--force]',
                  help='Copy all items from SOURCE_BRANCH to '
                       'DEST_BRANCH. If DEST_BRANCH does not exist, '
                       'it will be created.')
@@ -690,8 +694,9 @@ def main():
                  help='Purge one or more PRODUCT_IDs from product '
                       'database and remove any locally replicated version.')
     p.add_option('--force', action='store_true',
-                 help='Force purge of product. Must be used with '
-                      '--purge-product option.')
+                 help='Force purge of product, force copy or force delete a '
+                 'branch. Must be used with --purge-product, --copy-branch '
+                 'or --delete-branch options.')
 
     options, arguments = p.parse_args()
 
@@ -717,9 +722,10 @@ def main():
     if options.new_branch:
         new_branch(options.new_branch)
     if options.copy_branch:
-        copy_branches(options.copy_branch[0], options.copy_branch[1])
+        copy_branches(
+            options.copy_branch[0], options.copy_branch[1], force=options.force)
     if options.delete_branch:
-        delete_branch(options.delete_branch)
+        delete_branch(options.delete_branch, force=options.force)
     if options.diff_branch:
         diff_branches(options.diff_branch)
     if options.add_product:

--- a/code/repoutil
+++ b/code/repoutil
@@ -566,16 +566,13 @@ def delete_branch(branchname, force=False):
     if not branchname in catalog_branches:
         reposadocommon.print_stderr('Branch %s does not exist!', branchname)
         return
-    if force:
-        del catalog_branches[branchname]
-        deleteBranchCatalogs(branchname)
-        reposadocommon.writeCatalogBranches(catalog_branches)
-        return
-    answer = raw_input('Really remove branch %s? [y/n] ' % branchname)
-    if answer.lower().startswith('y'):
-        del catalog_branches[branchname]
-        deleteBranchCatalogs(branchname)
-        reposadocommon.writeCatalogBranches(catalog_branches)
+    if not force:
+        answer = raw_input('Really remove branch %s? [y/n] ' % branchname)
+        if not answer.lower().startswith('y'):
+            return
+    del catalog_branches[branchname]
+    deleteBranchCatalogs(branchname)
+    reposadocommon.writeCatalogBranches(catalog_branches)
 
 
 def new_branch(branchname):


### PR DESCRIPTION
This change adds a preference that allows someone to disable the prompt that is initiated when you attempt to copy a branch to another branch that already exists. The proposed code change doesn't change any default behavior but allows someone to set `PromptForBranchCopies` to `False` to allow for automation in copying branches if necessary. Happy to change the key name `PromptForBranchCopies` to something else if proposed.  