### PR TITLE
config data support without replicating packages.

### DIFF
--- a/code/repo_sync
+++ b/code/repo_sync
@@ -818,7 +818,8 @@ def main():
             reposadocommon.print_stderr('ERROR: curl tool not found at %s',
                                         reposadocommon.pref('CurlPath'))
             exit(-1)
-        if not reposadocommon.pref('LocalCatalogURLBase'):
+        if (not reposadocommon.pref('LocalCatalogURLBase') or
+                reposadocommon.pref('SkipPackages')):
             download_packages = False
         else:
             download_packages = True

--- a/code/repo_sync
+++ b/code/repo_sync
@@ -819,7 +819,7 @@ def main():
                                         reposadocommon.pref('CurlPath'))
             exit(-1)
         if (not reposadocommon.pref('LocalCatalogURLBase') or
-                reposadocommon.pref('SkipPackages')):
+                reposadocommon.pref('AlwaysRewriteDistributionURLs')):
             download_packages = False
         else:
             download_packages = True

--- a/code/reposadolib/reposadocommon.py
+++ b/code/reposadolib/reposadocommon.py
@@ -339,22 +339,24 @@ def rewriteOneURL(full_url):
 
 def rewriteURLsForProduct(product):
     '''Rewrites the URLs for a product'''
-    if 'ServerMetadataURL' in product:
-        product['ServerMetadataURL'] = rewriteOneURL(
-            product['ServerMetadataURL'])
-    for package in product.get('Packages', []):
-        if 'URL' in package:
-            package['URL'] = rewriteOneURL(package['URL'])
-        if 'MetadataURL' in package:
-            package['MetadataURL'] = rewriteOneURL(
-                package['MetadataURL'])
-        # workaround for 10.8.2 issue where client ignores local pkg
-        # and prefers Apple's URL. Need to revisit as we better understand this
-        # issue
-        if 'Digest' in package:
-            # removing the Digest causes 10.8.2 to use the replica's URL
-            # instead of Apple's
-            del package['Digest']
+    only_distributions = pref('OnlyWriteDistributionURL')
+    if not only_distributions:
+        if 'ServerMetadataURL' in product:
+            product['ServerMetadataURL'] = rewriteOneURL(
+                product['ServerMetadataURL'])
+        for package in product.get('Packages', []):
+            if 'URL' in package:
+                package['URL'] = rewriteOneURL(package['URL'])
+            if 'MetadataURL' in package:
+                package['MetadataURL'] = rewriteOneURL(
+                    package['MetadataURL'])
+            # workaround for 10.8.2 issue where client ignores local pkg
+            # and prefers Apple's URL. Need to revisit as we better understand
+            # this issue
+            if 'Digest' in package:
+                # removing the Digest causes 10.8.2 to use the replica's URL
+                # instead of Apple's
+                del package['Digest']
     distributions = product['Distributions']
     for dist_lang in distributions.keys():
         distributions[dist_lang] = rewriteOneURL(

--- a/code/reposadolib/reposadocommon.py
+++ b/code/reposadolib/reposadocommon.py
@@ -339,7 +339,7 @@ def rewriteOneURL(full_url):
 
 def rewriteURLsForProduct(product):
     '''Rewrites the URLs for a product'''
-    only_distributions = pref('OnlyWriteDistributionURL')
+    only_distributions = pref('AlwaysRewriteDistributionURLs')
     if not only_distributions:
         if 'ServerMetadataURL' in product:
             product['ServerMetadataURL'] = rewriteOneURL(

--- a/docs/reposado_preferences.md
+++ b/docs/reposado_preferences.md
@@ -105,6 +105,17 @@ The following keys are optional and may be defined in preferences.plist for spec
 
 	Defaults to displaying size in bytes.
 
+- AlwaysRewriteDistributionURLs
+
+	This boolean preference allows for rewriting of the DistributionURLs inside the catalogs so they point to the LocalCatalogURLBase. This preference is intended for the ability to modify config-data on products without replicating packages. More info for why you would want to do this [here.][1]
+
+	Note: Setting this preference to True will keep reposado from downloading packages.
+
+	Example:
+
+	    <key>AlwaysRewriteDistributionURLs</key>
+	    <true/>
+
 
 ## Example preferences.plist
 
@@ -120,3 +131,5 @@ The following keys are optional and may be defined in preferences.plist for spec
 	    <string>/Volumes/data/reposado/metadata</string>
 	</dict>
 	</plist>
+
+[1]: https://managingosx.wordpress.com/2015/01/30/gatekeeper-configuration-data-and-xprotectplistconfigdata-and-munki-and-reposado-oh-my/


### PR DESCRIPTION
At the current time you can not use the feature `--remove-config-data all` without replicating the packages. This PR allows you to rewrite just the distribution URLs so the client knows where to look for custom distribution files, some of which may contain edited config data attributes. 

Setting a preference of `SkipPackages` to `True` and `OnlyWriteDistributionURL` to `True` will enable this feature. You would of course also need to have `LocalCatalogURLBase` set as well. 

Happy to change preference names but this is the best solution I could come to, with the least amount of code changes. I can add documentation for this if it is decided to merge this. 