### PR TITLE
fix shebangs to explicitly use python2

### DIFF
--- a/code/repo_sync
+++ b/code/repo_sync
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # encoding: utf-8
 #
 # Copyright 2011 Disney Enterprises, Inc. All rights reserved

--- a/code/repoutil
+++ b/code/repoutil
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # encoding: utf-8
 #
 # Copyright 2011 Disney Enterprises, Inc. All rights reserved


### PR DESCRIPTION
This makes the scripts work natively on systems where the default is Python3, and should be backwards compatible to older systems