### PR TITLE
Download and rewrite URLs for IntegrityDataURL as well

### DIFF
--- a/code/repo_sync
+++ b/code/repo_sync
@@ -712,6 +712,16 @@ def sync(fast_scan=False, download_packages=True):
                                         'Could not replicate %s: %s',
                                         package['MetadataURL'], err)
                                     continue
+                            if 'IntegrityDataURL' in package:
+                                try:
+                                    unused_path = replicateURLtoFilesystem(
+                                        package['IntegrityDataURL'],
+                                        copy_only_if_missing=fast_scan)
+                                except ReplicationError, err:
+                                    reposadocommon.print_stderr(
+                                        'Could not replicate %s: %s',
+                                        package['IntegrityDataURL'], err)
+                                    continue
 
                     # calculate total size
                     size = 0

--- a/code/reposadolib/reposadocommon.py
+++ b/code/reposadolib/reposadocommon.py
@@ -351,6 +351,9 @@ def rewriteURLsForProduct(product):
         if 'MetadataURL' in package:
             package['MetadataURL'] = rewriteOneURL(
                 package['MetadataURL'])
+        if 'IntegrityDataURL' in package:
+            package['IntegrityDataURL'] = rewriteOneURL(
+                package['IntegrityDataURL'])
         # workaround for 10.8.2 issue where client ignores local pkg
         # and prefers Apple's URL. Need to revisit as we better understand this
         # issue


### PR DESCRIPTION
Including IntegrityDataURL's to be downloaded as well. This seems to be a fairly recent addition.
Currently these get ignored and left pointing to apple's servers in the catalog - so it breaks updates if machines don't have access to the internet.
Example of what these look like:
`				<dict>
					<key>IntegrityDataSize</key>
					<integer>5792</integer>
					<key>IntegrityDataURL</key>
					<string>http://swcdn.apple.com/content/downloads/25/52/041-09593/q874q3nojlnly8g4ujj7hx9iza4skhqjoq/macOSUpdCombo10.14.2Auto.pkg.integrityDataV1</string>
					<key>MetadataURL</key>
					<string>https://server.local.domain/content/downloads/25/52/041-09593/q874q3nojlnly8g4ujj7hx9iza4skhqjoq/macOSUpdCombo10.14.2Auto.pkm</string>
					<key>Size</key>
					<integer>1661472357</integer>
					<key>URL</key>
					<string>https://server.local.domain/content/downloads/25/52/041-09593/q874q3nojlnly8g4ujj7hx9iza4skhqjoq/macOSUpdCombo10.14.2Auto.pkg</string>
				</dict>`