### PR TITLE
Separate SSL URL option and related URL rewrites

### DIFF
--- a/code/repo_sync
+++ b/code/repo_sync
@@ -712,6 +712,16 @@ def sync(fast_scan=False, download_packages=True):
                                         'Could not replicate %s: %s',
                                         package['MetadataURL'], err)
                                     continue
+                            if 'IntegrityDataURL' in package:
+                                try:
+                                    unused_path = replicateURLtoFilesystem(
+                                        package['IntegrityDataURL'],
+                                        copy_only_if_missing=fast_scan)
+                                except ReplicationError, err:
+                                    reposadocommon.print_stderr(
+                                        'Could not replicate %s: %s',
+                                        package['IntegrityDataURL'], err)
+                                    continue
 
                     # calculate total size
                     size = 0

--- a/code/reposadolib/reposadocommon.py
+++ b/code/reposadolib/reposadocommon.py
@@ -143,6 +143,10 @@ def configure_prefs():
          'Base URL for your local Software Update Service\n(Example: '
          'http://su.your.org -- leave empty if you are not replicating '
          'updates)'),
+        ('LocalCatalogSSLURLBase',
+         'Base SSL URL for your local Software Update Service\n(Example: '
+         'https://su.your.org -- OPTIONAL to replace any HTTPS URLs '
+         'leave empty for HTTP only)'),
         ]
     if not os.path.exists(pref('CurlPath')):
         keysAndPrompts.append(
@@ -330,7 +334,10 @@ def getLocalPathNameFromURL(url, root_dir=None):
 
 def rewriteOneURL(full_url):
     '''Rewrites a single URL to point to our local replica'''
-    our_base_url = pref('LocalCatalogURLBase')
+    if pref('LocalCatalogSSLURLBase') and full_url.startswith('https'):
+        our_base_url = pref('LocalCatalogSSLURLBase')
+    else:
+        our_base_url = pref('LocalCatalogURLBase')
     if not full_url.startswith(our_base_url):
         # only rewrite the URL if needed
         (unused_scheme, unused_netloc,

--- a/code/reposadolib/reposadocommon.py
+++ b/code/reposadolib/reposadocommon.py
@@ -351,6 +351,9 @@ def rewriteURLsForProduct(product):
         if 'MetadataURL' in package:
             package['MetadataURL'] = rewriteOneURL(
                 package['MetadataURL'])
+        if 'IntegrityDataURL' in package:
+            package['IntegrityDataURL'] = rewriteOneURL(
+                package['IntegrityDataURL'])
         # workaround for 10.8.2 issue where client ignores local pkg
         # and prefers Apple's URL. Need to revisit as we better understand this
         # issue


### PR DESCRIPTION
I noticed that while MacOS 10.14 requires SSL for the catalog and certain things inside the catalog, Apple isn't exclusively using it. There's plenty of entries - notably 'URLs' (the pkg files) being served over http direct from Apple.

This adds an extra preference 'LocalCatalogSSLURLBase' and, if this is set, the 'LocalCatalogURLBase' will be used for http URLs and 'LocalCatalogSSLURLBase' for https URLs. The way it's implemented should mean no breakages for existing installs and external projects (i.e. margarita).

If you think this is a good idea it will also need some documentation updates and maybe some other small changes to clarify the behaviour. I'm just not sure how necessary this is - every version of MacOS (10.10+) I've tested is happy with everything being served over SSL, so it would just come down to the performance impact.