### PR TITLE
tweak to not choke on http2

### DIFF
--- a/code/repo_sync
+++ b/code/repo_sync
@@ -296,6 +296,7 @@ def curl(url, destinationpath, onlyifnewer=False, etag=None, resume=False):
         print >> fileobj, 'dump-header -'  # dump headers to stdout
         print >> fileobj, 'speed-time = 30' # give up if too slow d/l
         print >> fileobj, 'tlsv1'          # use only TLS 1.x
+	print >> fileobj, 'http1.1'        # disable http2
         print >> fileobj, 'url = "%s"' % url
 
         # add additional options from our prefs


### PR DESCRIPTION
Some of the servers appear to have switched to http2, and no longer have a description after the return code in the headers. The parsing (around line 348) chokes on the missing description.
This forces http 1.1 so we have the code and the description of the code.
(another option would be to update the code to handle no description from the server)