### PR TITLE
Add --catalogs-only option to repo_sync

### DIFF
--- a/code/repo_sync
+++ b/code/repo_sync
@@ -828,6 +828,8 @@ def main():
                       help='Log all output to LOGFILE. No output to STDOUT.')
     parser.add_option('--recheck', action='store_true',
                       help='Recheck already downloaded packages for changes.')
+    parser.add_option('--catalogs-only', action="store_true", dest="catalogs_only",
+                      help='Only download catalogs. No packages.')
 
     options, unused_arguments = parser.parse_args()
     if reposadocommon.validPreferences():
@@ -835,7 +837,7 @@ def main():
             reposadocommon.print_stderr('ERROR: curl tool not found at %s',
                                         reposadocommon.pref('CurlPath'))
             exit(-1)
-        if not reposadocommon.pref('LocalCatalogURLBase'):
+        if options.catalogs_only or not reposadocommon.pref('LocalCatalogURLBase'):
             download_packages = False
         else:
             download_packages = True


### PR DESCRIPTION
To skip downloading packages, you have to make sure the `LocalCatalogURLBase` value is empty in the preferences plist. Doing this inside a docker container means having to use volumes to provide your own custom preferences plist.

I added a `--catalogs-only` option, which will set `download_packages` to false, same as when the `LocalCatalogURLBase` value is empty. That allows docker users to sync without packages without having to provide their own preferences plist.